### PR TITLE
サインインからの例外日対応

### DIFF
--- a/frontend/react/reducers/TrashReducer.js
+++ b/frontend/react/reducers/TrashReducer.js
@@ -97,10 +97,15 @@ const TrashReducer = (state=initialState,action)=> {
         return new_state;
     }
     case ActionType.SET_USER_INFO:
-    case ActionType.SET_PRESET: 
+    case ActionType.SET_PRESET:
     {
         if(action.preset.length > 0) {
             new_state.trashes = _.cloneDeep(action.preset);
+            new_state.trashes.forEach(trash=>{
+                if(trash.excludes === undefined) {
+                    trash.excludes = [];
+                }
+            });
             new_state.error = common_check.exist_error(new_state.trashes);
         }
         return new_state;
@@ -114,7 +119,7 @@ const TrashReducer = (state=initialState,action)=> {
         const check_result = new_state.trashes[action.index].excludes.every((value)=>{
             if(value.month >=1 && value.month <= 12 && value.date >= 1) {
                 if((value.month == 2 && value.date <= 29) ||
-                    ([1,3,5,7,8,9].includes(value.month) && value.date <= 31) || 
+                    ([1,3,5,7,8,9].includes(value.month) && value.date <= 31) ||
                     value.date <= 30) {
                     return true;
                 }

--- a/frontend/react/test/reducers_test.js
+++ b/frontend/react/test/reducers_test.js
@@ -12,20 +12,20 @@ multiInitialState.trashes.push(_.cloneDeep(initialState.trashes[0]));
 describe('updateState',()=>{
     it('Add Trash Type',()=>{
         const state = TestReducer(undefined,{type:ActionType.ADD_TRASH});
-        assert.deepEqual(multiInitialState,state);
+        assert.deepStrictEqual(multiInitialState,state);
     });
     describe('change trash',()=>{
         it('single trash',()=>{
             let except = _.cloneDeep(initialState);
             except.trashes[0].type='bin';
             const state = TestReducer(undefined,{type:ActionType.CHANGE_TRASH,value:'bin',index:0});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
         it('multi trash',()=>{
             let except = _.cloneDeep(multiInitialState);
             except.trashes[1].type='bin';
             const state = TestReducer(multiInitialState,{type:ActionType.CHANGE_TRASH,value:'bin',index:1});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
     });
     describe('change schedule',()=>{
@@ -35,7 +35,7 @@ describe('updateState',()=>{
             Object.assign(except.trashes[0].schedules[1],{error: undefined, type: 'month',value:''});
             except.error = true; //monthの場合は入力必須のため初期状態はエラー
             const state = TestReducer(undefined,{type:ActionType.CHANGE_SCHEDULE,index:[0,1],value:'month'});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
         it('multi trash',()=>{
             let except = _.cloneDeep(multiInitialState);
@@ -52,7 +52,7 @@ describe('updateState',()=>{
             teststate.trashes[1].schedules.push({error: undefined, type: 'weekday', value: '0'});
             let state = TestReducer(teststate,{type:ActionType.CHANGE_SCHEDULE,index:[0,2],value:'biweek'});
             state = TestReducer(state,{type:ActionType.CHANGE_SCHEDULE,index:[1,1],value:'weekday'});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
     });
     describe('change input',()=>{
@@ -64,7 +64,7 @@ describe('updateState',()=>{
             Object.assign(teststate.trashes[0].schedules[0],{type:'month'});
 
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,0],value:'13'});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
         it('multi trash',()=>{
             let except = _.cloneDeep(multiInitialState);
@@ -83,7 +83,7 @@ describe('updateState',()=>{
             Object.assign(teststate.trashes[1].schedules[2],{type:'week',value:'3',error: undefined});
 
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,1],value:'1-1'});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
         it('required error',()=>{
             let except = 'missingvalue';
@@ -92,8 +92,8 @@ describe('updateState',()=>{
             teststate.trashes[0].schedules.push({type: 'weekday', value: '0'});
             teststate.trashes[0].schedules[1].type = 'month';
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,1],value:''});
-            assert.equal(except,state.trashes[0].schedules[1].error);
-            assert.equal(true,state.error);
+            assert.strictEqual(except,state.trashes[0].schedules[1].error);
+            assert.strictEqual(true,state.error);
         });
         it('number error',()=>{
             let except = 'wrongnumber';
@@ -101,8 +101,8 @@ describe('updateState',()=>{
             teststate.trashes[0].schedules.push({type: 'weekday', value: '0'});
             teststate.trashes[0].schedules[1].type = 'month';
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,1],value:'a'});
-            assert.equal(except,state.trashes[0].schedules[1].error);
-            assert.equal(true,state.error);
+            assert.strictEqual(except,state.trashes[0].schedules[1].error);
+            assert.strictEqual(true,state.error);
         });
         it('min error',()=>{
             let expect = 'wrongminnumber';
@@ -110,8 +110,8 @@ describe('updateState',()=>{
             teststate.trashes[0].schedules.push({type: 'weekday', value: '0'});
             teststate.trashes[0].schedules[1].type = 'month';
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,1],value:'0'});
-            assert.equal(expect,state.trashes[0].schedules[1].error);
-            assert.equal(true,state.error);
+            assert.strictEqual(expect,state.trashes[0].schedules[1].error);
+            assert.strictEqual(true,state.error);
         });
         it('max error',()=>{
             let expect = 'wrongmaxnumber';
@@ -119,8 +119,8 @@ describe('updateState',()=>{
             teststate.trashes[0].schedules.push({type: 'weekday', value: '0'});
             teststate.trashes[0].schedules[1].type = 'month';
             let state = TestReducer(teststate,{type:ActionType.CHANGE_INPUT,index:[0,1],value:'32'});
-            assert.equal(expect,state.trashes[0].schedules[1].error);
-            assert.equal(true,state.error);
+            assert.strictEqual(expect,state.trashes[0].schedules[1].error);
+            assert.strictEqual(true,state.error);
         });
     });
     describe('input other trash type',()=>{
@@ -132,7 +132,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0,value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('right input alphabet,number',()=>{
             const input_value = '0099AA';
@@ -142,7 +142,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0,value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('right input kana',()=>{
             const input_value = 'スチロール';
@@ -152,7 +152,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0,value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('right input whitespace',()=>{
             const input_value = 'My Trash';
@@ -162,7 +162,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0,value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('requirement error',()=>{
             let expect = _.cloneDeep(initialState);
@@ -171,7 +171,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0,value: '',maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('elegular error script',()=>{
             const input_value = '<script/>';
@@ -181,7 +181,7 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0, value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('elegular error SQL injection',()=>{
             const input_value = 'or x=\'x\';';
@@ -191,36 +191,36 @@ describe('updateState',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index: 0, value: input_value,maxlength:10});
-            assert.deepEqual(state.trashes[0],expect.trashes[0]);
+            assert.deepStrictEqual(state.trashes[0],expect.trashes[0]);
         });
         it('max length',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index:0,value:'これは１０文字の入力',maxlength:10});
-            assert.equal(state.trashes[0].input_trash_type_error,undefined);
+            assert.strictEqual(state.trashes[0].input_trash_type_error,undefined);
         });
         it('max lengthの最大値変更',()=>{
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index:0,value:'１２文字の入力でも大丈夫',maxlength:20});
-            assert.equal(state.trashes[0].input_trash_type_error,undefined);
+            assert.strictEqual(state.trashes[0].input_trash_type_error,undefined);
         });
         it('length over',()=>{
             let expect = 'wronglengthstring';
             let teststate = _.cloneDeep(initialState);
             teststate.trashes[0].type = 'other';
             let state = TestReducer(teststate,{type:ActionType.INPUT_TRASH_TYPE,index:0,value:'これは１１文字の入力だ',maxlength:10});
-            assert.equal(state.trashes[0].input_trash_type_error,expect);
+            assert.strictEqual(state.trashes[0].input_trash_type_error,expect);
         });
     });
     describe('delete trash',()=>{
         it('multi to single',()=>{
             let state = TestReducer(multiInitialState,{type:ActionType.DEL_TRASH,index:0});
-            assert.deepEqual(initialState,state);
+            assert.deepStrictEqual(initialState,state);
         });
         it('single to zero',()=>{
             let state = TestReducer(initialState,{type:ActionType.DEL_TRASH,index:0});
-            assert.equal(0,state.trashes.length);
+            assert.strictEqual(0,state.trashes.length);
         });
         it('multi delete',()=>{
             let teststate = _.cloneDeep(multiInitialState);
@@ -228,20 +228,34 @@ describe('updateState',()=>{
             let except = _.cloneDeep(initialState);
             except.trashes[0].type='paper';
             let state = TestReducer(teststate,{type:ActionType.DEL_TRASH,index:1});
-            assert.deepEqual(except,state);
+            assert.deepStrictEqual(except,state);
         });
     });
     describe('set preset', ()=>{
         it('has preset', ()=>{
             const preset = [
+                {type:'burn',schedules:[{type:'weekday',value:'3'}], excludes:[{month: 12, date: 1}]}];
+            let state = TestReducer(initialState, {type:ActionType.SET_USER_INFO, preset: preset});
+            assert.strictEqual(state.trashes[0].schedules.length,1);
+            assert.strictEqual(state.trashes[0].type,'burn');
+            assert.strictEqual(state.trashes[0].schedules[0].type,'weekday');
+            assert.strictEqual(state.trashes[0].schedules[0].value,'3');
+            assert.strictEqual(state.trashes[0].excludes[0].month,12);
+            assert.strictEqual(state.trashes[0].excludes[0].date,1);
+            assert.strictEqual(state.error,false);
+            assert.deepStrictEqual(state.trashes[0].schedules[0],preset[0].schedules[0]);
+        });
+        it('excludesが無いプリセットは空配列で補完される', ()=>{
+            const preset = [
                 {type:'burn',schedules:[{type:'weekday',value:'3'}]}];
             let state = TestReducer(initialState, {type:ActionType.SET_USER_INFO, preset: preset});
-            assert.equal(state.trashes[0].schedules.length,1);
-            assert.equal(state.trashes[0].type,'burn');
-            assert.equal(state.trashes[0].schedules[0].type,'weekday');
-            assert.equal(state.trashes[0].schedules[0].value,'3');
-            assert.equal(state.error,false);
-            assert.deepEqual(state.trashes[0].schedules[0],preset[0].schedules[0]);
+            assert.strictEqual(state.trashes[0].schedules.length,1);
+            assert.strictEqual(state.trashes[0].type,'burn');
+            assert.strictEqual(state.trashes[0].schedules[0].type,'weekday');
+            assert.strictEqual(state.trashes[0].schedules[0].value,'3');
+            assert.strictEqual(state.error,false);
+            assert.strictEqual(state.trashes[0].excludes.length, 0);
+            assert.deepStrictEqual(state.trashes[0].schedules[0],preset[0].schedules[0]);
         });
     });
 });
@@ -250,19 +264,19 @@ describe('SubmitState',()=> {
     describe('submitting',()=>{
         it('submit true',()=>{
             const state = SubmitReducer(undefined,{type:ActionType.SET_SUBMITTING,value:true});
-            assert.equal(true,state.submitting);
+            assert.strictEqual(true,state.submitting);
         });
         it('submit false',()=>{
             const state = SubmitReducer({submitting:true},{type:ActionType.SET_SUBMITTING,value:false});
-            assert.equal(false,state.submitting);
+            assert.strictEqual(false,state.submitting);
         });
         it('open error Dialog', ()=>{
             const state = SubmitReducer(undefined, {type:ActionType.ERROR_DIALOG, open: true});
-            assert.equal(state.showErrorDialog, true);
+            assert.strictEqual(state.showErrorDialog, true);
         });
         it('close error Dialog', ()=>{
             const state = SubmitReducer({showErrorDialog:true}, {type:ActionType.ERROR_DIALOG, open: false});
-            assert.equal(state.showErrorDialog, false);
+            assert.strictEqual(state.showErrorDialog, false);
         });
     });
 });


### PR DESCRIPTION
・プリセットデータを設定する際にexcludesが含まれないデータは例外日設定でエラーになることから、空配列を設定するように修正。
・テストコードのdeprecatedを解消